### PR TITLE
Configure Linux & macOS multi-arch releases using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ addons:
     packages:
       - libssl-dev
 
+      # Cross compiler dependencies for ARM
+      - gcc-arm-linux-gnueabihf
+      - libc6-armhf-cross
+      - libc6-dev-armhf-cross
+
 stages:
   - build
   - test
@@ -41,18 +46,18 @@ jobs:
       rust: stable
       env: TARGET=armv7-unknown-linux-gnuabifh
       script: *build-script-cross
-    - stage: build
-      rust: stable
-      env: TARGET=i686-unknown-freebsd
-      script: *build-script-cross
-    - stage: build
-      rust: stable
-      env: TARGET=x86_64-unknown-freebsd
-      script: *build-script-cross
-    - stage: build
-      rust: stable
-      env: TARGET=x86_64-unknown-netbsd
-      script: *build-script-cross
+    # - stage: build
+    #   rust: stable
+    #   env: TARGET=i686-unknown-freebsd
+    #   script: *build-script-cross
+    # - stage: build
+    #   rust: stable
+    #   env: TARGET=x86_64-unknown-freebsd
+    #   script: *build-script-cross
+    # - stage: build
+    #   rust: stable
+    #   env: TARGET=x86_64-unknown-netbsd
+    #   script: *build-script-cross
     - stage: build
       rust: beta
       env: TARGET=x86_64-unknown-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ addons:
     packages:
       - libssl-dev
 
-      # Cross compiler dependencies for ARM
-      # - gcc-arm-linux-gnueabihf
-      # - libc6-armhf-cross
-      # - libc6-dev-armhf-cross
-
 stages:
   - build
   - test
@@ -69,12 +64,18 @@ jobs:
     - stage: release
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu
-      script:
-        - cargo build --release --verbose --all
+      script: &script-github-release
+        - |
+          if [ $TARGET == "x86_64-unknown-linux-gnu" ] || [ $TARGET == "x86_64-apple-darwin" ]; then
+            cargo build --release --verbose --all
+          else
+            echo 'Starting build using cross for cross compilation...'
+            cross build --target $TARGET --release --verbose --all
+          fi
         - cd target/release
         - tar -czvf $TRAVIS_BUILD_DIR/ffsend-$TARGET.tar.gz ffsend
         - cd $TRAVIS_BUILD_DIR
-      deploy: &deploy-github-release-cross
+      deploy: &deploy-github-release
         provider: releases
         api_key: $GITHUB_OAUTH_TOKEN
         skip_cleanup: true
@@ -89,43 +90,35 @@ jobs:
       env: TARGET=i686-unknown-linux-gnu
       install: &install-github-release-cross
         - cargo install cross
-      script: &script-github-release-cross
-        - cross build --target $TARGET --release --verbose --all
-        - cd target/release
-        - tar -czvf $TRAVIS_BUILD_DIR/ffsend-$TARGET.tar.gz ffsend
-        - cd $TRAVIS_BUILD_DIR
-      deploy: *deploy-github-release-cross
+      script: *script-github-release
+      deploy: *deploy-github-release
 
     # GitHub binary release for Linux on arch
     - stage: release
       rust: stable
       env: TARGET=aarch64-unknown-linux-gnu
       install: *install-github-release-cross
-      script: *script-github-release-cross
-      deploy: *deploy-github-release-cross
+      script: *script-github-release
+      deploy: *deploy-github-release
     - stage: release
       rust: stable
       install: *install-github-release-cross
-      script: *script-github-release-cross
-      deploy: *deploy-github-release-cross
+      script: *script-github-release
+      deploy: *deploy-github-release
     - stage: release
       rust: stable
       env: TARGET=armv7-unknown-linux-gnueabihf
       install: *install-github-release-cross
-      script: *script-github-release-cross
-      deploy: *deploy-github-release-cross
+      script: *script-github-release
+      deploy: *deploy-github-release
 
     # GitHub binary release for macOX
     - stage: release
       rust: stable
       os: osx
       env: TARGET=x86_64-apple-darwin
-      script:
-        - cargo build --release --verbose --all
-        - cd target/release
-        - tar -czvf $TRAVIS_BUILD_DIR/ffsend-$TARGET.tar.gz ffsend
-        - cd $TRAVIS_BUILD_DIR
-      deploy: *deploy-github-release-cross
+      script: *script-github-release
+      deploy: *deploy-github-release
 
 # TODO: add (Free)BSD architecture
 # TODO: use regular cargo commands for x86_64 linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
     # Linux with Rust stable/beta/nightly
     - stage: build
       rust: stable
-      env: TARGET=x86_64-unknown-linux-gnu CACHE_NAME=$TARGET-stable
+      env: TARGET=x86_64-unknown-linux-gnu
       cache: cargo
       script: &build-script
         - cargo build --verbose --all
@@ -31,12 +31,12 @@ jobs:
         - cargo build --features no-color --verbose --all
     - stage: build
       rust: beta
-      env: TARGET=x86_64-unknown-linux-gnu CACHE_NAME=$TARGET-beta
+      env: TARGET=x86_64-unknown-linux-gnu
       cache: cargo
       script: *build-script
     - stage: build
       rust: nightly
-      env: TARGET=x86_64-unknown-linux-gnu CACHE_NAME=$TARGET-nightly
+      env: TARGET=x86_64-unknown-linux-gnu
       cache: cargo
       script: *build-script
 
@@ -44,7 +44,7 @@ jobs:
     - stage: build
       rust: stable
       os: osx
-      env: TARGET=x86_64-apple-darwin CACHE_NAME=$TARGET-stable
+      env: TARGET=x86_64-apple-darwin
       cache: cargo
       script: *build-script
 
@@ -53,7 +53,7 @@ jobs:
     ################################
 
     - stage: test
-      env: TARGET=x86_64-unknown-linux-gnu CACHE_NAME=$TARGET-stable
+      env: TARGET=x86_64-unknown-linux-gnu
       cache: cargo
       script: cargo test --verbose --all
 
@@ -63,7 +63,7 @@ jobs:
 
     # Cargo crate release
     - stage: release
-      env: TARGET=x86_64-unknown-linux-gnu CACHE_NAME=$TARGET-stable
+      env: TARGET=x86_64-unknown-linux-gnu
       cache: cargo
       script:
         - echo $CARGO_TOKEN | cargo login
@@ -72,7 +72,7 @@ jobs:
     # GitHub binary release for Linux on x86/x86_64
     - stage: release
       rust: stable
-      env: TARGET=x86_64-unknown-linux-gnu CACHE_NAME=$TARGET-stable
+      env: TARGET=x86_64-unknown-linux-gnu
       cache: cargo
       script: &script-github-release
         - |
@@ -96,7 +96,7 @@ jobs:
           branch: master
     - stage: release
       rust: stable
-      env: TARGET=i686-unknown-linux-gnu CACHE_NAME=$TARGET-stable
+      env: TARGET=i686-unknown-linux-gnu
       cache: cargo
       install: &install-github-release-cross
         - cargo install cross
@@ -106,21 +106,21 @@ jobs:
     # GitHub binary release for Linux on arch
     - stage: release
       rust: stable
-      env: TARGET=aarch64-unknown-linux-gnu CACHE_NAME=$TARGET-stable
+      env: TARGET=aarch64-unknown-linux-gnu
       cache: cargo
       install: *install-github-release-cross
       script: *script-github-release
       deploy: *deploy-github-release
     - stage: release
       rust: stable
-      env: TARGET=arm-unknown-linux-gnueabi CACHE_NAME=$TARGET-stable
+      env: TARGET=arm-unknown-linux-gnueabi
       cache: cargo
       install: *install-github-release-cross
       script: *script-github-release
       deploy: *deploy-github-release
     - stage: release
       rust: stable
-      env: TARGET=armv7-unknown-linux-gnueabihf CACHE_NAME=$TARGET-stable
+      env: TARGET=armv7-unknown-linux-gnueabihf
       cache: cargo
       install: *install-github-release-cross
       script: *script-github-release
@@ -130,7 +130,7 @@ jobs:
     - stage: release
       rust: stable
       os: osx
-      env: TARGET=x86_64-apple-darwin CACHE_NAME=$TARGET-stable
+      env: TARGET=x86_64-apple-darwin
       cache: cargo
       script: *script-github-release
       deploy: *deploy-github-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,7 @@ jobs:
       deploy: *deploy-github-release
     - stage: release
       rust: stable
+      env: TARGET=arm-unknown-linux-gnueabi
       install: *install-github-release-cross
       script: *script-github-release
       deploy: *deploy-github-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,11 @@ jobs:
       script: *build-script-cross
     - stage: build
       rust: stable
-      env: TARGET=arm-unknown-linux-gnuabihf
+      env: TARGET=arm-unknown-linux-gnueabi
       script: *build-script-cross
     - stage: build
       rust: stable
-      env: TARGET=armv7-unknown-linux-gnuabihf
+      env: TARGET=armv7-unknown-linux-gnueabihf
       script: *build-script-cross
     # - stage: build
     #   rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,26 @@ jobs:
       env: TARGET=aarch64-unknown-linux-gnu
       script: *build-script-cross
     - stage: build
+      rust: stable
+      env: TARGET=arm-unknown-linux-gnuabifh
+      script: *build-script-cross
+    - stage: build
+      rust: stable
+      env: TARGET=armv7-unknown-linux-gnuabifh
+      script: *build-script-cross
+    - stage: build
+      rust: stable
+      env: TARGET=i686-unknown-freebsd
+      script: *build-script-cross
+    - stage: build
+      rust: stable
+      env: TARGET=x86_64-unknown-freebsd
+      script: *build-script-cross
+    - stage: build
+      rust: stable
+      env: TARGET=x86_64-unknown-netbsd
+      script: *build-script-cross
+    - stage: build
       rust: beta
       env: TARGET=x86_64-unknown-linux-gnu
       script: *build-script-cross
@@ -50,7 +70,6 @@ jobs:
         - cargo build --no-default-features --verbose --all
         - cargo build --features no-color --verbose --all
     - stage: test
-      env: TARGET=x86_64-unknown-linux-gnu
       script: cargo test --verbose --all
       cache: cargo
     - stage: release

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,22 +23,29 @@ jobs:
     # Linux with Rust stable/beta/nightly
     - stage: build
       rust: stable
+      env: TARGET=x86_64-unknown-linux-gnu CACHE_NAME=$TARGET-stable
+      cache: cargo
       script: &build-script
         - cargo build --verbose --all
         - cargo build --no-default-features --verbose --all
         - cargo build --features no-color --verbose --all
-      cache: cargo
     - stage: build
       rust: beta
+      env: TARGET=x86_64-unknown-linux-gnu CACHE_NAME=$TARGET-beta
+      cache: cargo
       script: *build-script
     - stage: build
       rust: nightly
+      env: TARGET=x86_64-unknown-linux-gnu CACHE_NAME=$TARGET-nightly
+      cache: cargo
       script: *build-script
 
     # macOS with Rust stable
     - stage: build
       rust: stable
       os: osx
+      env: TARGET=x86_64-apple-darwin CACHE_NAME=$TARGET-stable
+      cache: cargo
       script: *build-script
 
     ################################
@@ -46,8 +53,9 @@ jobs:
     ################################
 
     - stage: test
-      script: cargo test --verbose --all
+      env: TARGET=x86_64-unknown-linux-gnu CACHE_NAME=$TARGET-stable
       cache: cargo
+      script: cargo test --verbose --all
 
     ################################
     # Release stage                #
@@ -55,15 +63,17 @@ jobs:
 
     # Cargo crate release
     - stage: release
+      env: TARGET=x86_64-unknown-linux-gnu CACHE_NAME=$TARGET-stable
+      cache: cargo
       script:
         - echo $CARGO_TOKEN | cargo login
         - cargo publish --verbose
-      cache: cargo
 
     # GitHub binary release for Linux on x86/x86_64
     - stage: release
       rust: stable
-      env: TARGET=x86_64-unknown-linux-gnu
+      env: TARGET=x86_64-unknown-linux-gnu CACHE_NAME=$TARGET-stable
+      cache: cargo
       script: &script-github-release
         - |
           if [ $TARGET == "x86_64-unknown-linux-gnu" ] || [ $TARGET == "x86_64-apple-darwin" ]; then
@@ -84,10 +94,10 @@ jobs:
         on:
           tags: true
           branch: master
-      cache: cargo
     - stage: release
       rust: stable
-      env: TARGET=i686-unknown-linux-gnu
+      env: TARGET=i686-unknown-linux-gnu CACHE_NAME=$TARGET-stable
+      cache: cargo
       install: &install-github-release-cross
         - cargo install cross
       script: *script-github-release
@@ -96,19 +106,22 @@ jobs:
     # GitHub binary release for Linux on arch
     - stage: release
       rust: stable
-      env: TARGET=aarch64-unknown-linux-gnu
+      env: TARGET=aarch64-unknown-linux-gnu CACHE_NAME=$TARGET-stable
+      cache: cargo
       install: *install-github-release-cross
       script: *script-github-release
       deploy: *deploy-github-release
     - stage: release
       rust: stable
-      env: TARGET=arm-unknown-linux-gnueabi
+      env: TARGET=arm-unknown-linux-gnueabi CACHE_NAME=$TARGET-stable
+      cache: cargo
       install: *install-github-release-cross
       script: *script-github-release
       deploy: *deploy-github-release
     - stage: release
       rust: stable
-      env: TARGET=armv7-unknown-linux-gnueabihf
+      env: TARGET=armv7-unknown-linux-gnueabihf CACHE_NAME=$TARGET-stable
+      cache: cargo
       install: *install-github-release-cross
       script: *script-github-release
       deploy: *deploy-github-release
@@ -117,7 +130,8 @@ jobs:
     - stage: release
       rust: stable
       os: osx
-      env: TARGET=x86_64-apple-darwin
+      env: TARGET=x86_64-apple-darwin CACHE_NAME=$TARGET-stable
+      cache: cargo
       script: *script-github-release
       deploy: *deploy-github-release
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,16 +24,19 @@ jobs:
     - stage: build
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu
+      script: &build-script
+        - cargo build --verbose --all
+        - cargo build --no-default-features --verbose --all
+        - cargo build --features no-color --verbose --all
+      cache: cargo
+    - stage: build
+      rust: stable
+      env: TARGET=i686-unknown-linux-gnu
       script: &build-script-cross
         - cargo install cross
         - cross build --target $TARGET --verbose --all
         - cross build --target $TARGET --no-default-features --verbose --all
         - cross build --target $TARGET --features no-color --verbose --all
-      cache: cargo
-    - stage: build
-      rust: stable
-      env: TARGET=i686-unknown-linux-gnu
-      script: *build-script-cross
     - stage: build
       rust: stable
       env: TARGET=aarch64-unknown-linux-gnu
@@ -101,7 +104,8 @@ jobs:
         - cargo publish --verbose
       cache: cargo
 
-# TODO: more architectures
+# TODO: add BSD architecture
+# TODO: use regular cargo commands for x86_64 linux
 # TODO: release a build for each architecture
 # TODO: enfore the git tag/crate version equality for releases
 # TODO: disable addons/rust installation for GitHub release job

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ addons:
       - libssl-dev
 
       # Cross compiler dependencies for ARM
-      - gcc-arm-linux-gnueabihf
-      - libc6-armhf-cross
-      - libc6-dev-armhf-cross
+      # - gcc-arm-linux-gnueabihf
+      # - libc6-armhf-cross
+      # - libc6-dev-armhf-cross
 
 stages:
   - build
@@ -40,11 +40,11 @@ jobs:
       script: *build-script-cross
     - stage: build
       rust: stable
-      env: TARGET=arm-unknown-linux-gnuabifh
+      env: TARGET=arm-unknown-linux-gnuabihf
       script: *build-script-cross
     - stage: build
       rust: stable
-      env: TARGET=armv7-unknown-linux-gnuabifh
+      env: TARGET=armv7-unknown-linux-gnuabihf
       script: *build-script-cross
     # - stage: build
     #   rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,90 +21,112 @@ stages:
 
 jobs:
   include:
+    ################################
+    # Build stage                  #
+    ################################
+
+    # Linux with Rust stable/beta/nightly
     - stage: build
       rust: stable
-      env: TARGET=x86_64-unknown-linux-gnu
       script: &build-script
         - cargo build --verbose --all
         - cargo build --no-default-features --verbose --all
         - cargo build --features no-color --verbose --all
       cache: cargo
     - stage: build
-      rust: stable
-      env: TARGET=i686-unknown-linux-gnu
-      script: &build-script-cross
-        - cargo install cross
-        - cross build --target $TARGET --verbose --all
-        - cross build --target $TARGET --no-default-features --verbose --all
-        - cross build --target $TARGET --features no-color --verbose --all
-    - stage: build
-      rust: stable
-      env: TARGET=aarch64-unknown-linux-gnu
-      script: *build-script-cross
-    - stage: build
-      rust: stable
-      env: TARGET=arm-unknown-linux-gnueabi
-      script: *build-script-cross
-    - stage: build
-      rust: stable
-      env: TARGET=armv7-unknown-linux-gnueabihf
-      script: *build-script-cross
-    # - stage: build
-    #   rust: stable
-    #   env: TARGET=i686-unknown-freebsd
-    #   script: *build-script-cross
-    # - stage: build
-    #   rust: stable
-    #   env: TARGET=x86_64-unknown-freebsd
-    #   script: *build-script-cross
-    # - stage: build
-    #   rust: stable
-    #   env: TARGET=x86_64-unknown-netbsd
-    #   script: *build-script-cross
-    - stage: build
       rust: beta
-      env: TARGET=x86_64-unknown-linux-gnu
-      script: *build-script-cross
+      script: *build-script
     - stage: build
       rust: nightly
-      env: TARGET=x86_64-unknown-linux-gnu
-      script: *build-script-cross
+      script: *build-script
+
+    # macOS with Rust stable
     - stage: build
       rust: stable
       os: osx
-      env: TARGET=x86_64-unknown-linux-gnu
-      script:
-        - cargo build --verbose --all
-        - cargo build --no-default-features --verbose --all
-        - cargo build --features no-color --verbose --all
+      script: *build-script
+
+    ################################
+    # Test stage                   #
+    ################################
+
     - stage: test
       script: cargo test --verbose --all
       cache: cargo
-    - stage: release
-      env: TARGET=x86_64-unknown-linux-gnu
-      script:
-        - cargo install cross
-        - cross build --target $TARGET --release --verbose --all
-        - cd target/release
-        - tar -czvf $TRAVIS_BUILD_DIR/ffsend-linux-x86_64.tar.gz ffsend
-        - cd $TRAVIS_BUILD_DIR
-      deploy:
-        provider: releases
-        api_key: $GITHUB_OAUTH_TOKEN
-        skip_cleanup: true
-        overwrite: false
-        file: ffsend-x86_64-linux.tar.gz
-        on:
-          tags: true
-          branch: master
-      cache: cargo
+
+    ################################
+    # Release stage                #
+    ################################
+
+    # Cargo crate release
     - stage: release
       script:
         - echo $CARGO_TOKEN | cargo login
         - cargo publish --verbose
       cache: cargo
 
-# TODO: add BSD architecture
+    # GitHub binary release for Linux on x86/x86_64
+    - stage: release
+      rust: stable
+      env: TARGET=x86_64-unknown-linux-gnu
+      script:
+        - cargo build --release --verbose --all
+        - cd target/release
+        - tar -czvf $TRAVIS_BUILD_DIR/ffsend-$TARGET.tar.gz ffsend
+        - cd $TRAVIS_BUILD_DIR
+      deploy: &deploy-github-release-cross
+        provider: releases
+        api_key: $GITHUB_OAUTH_TOKEN
+        skip_cleanup: true
+        overwrite: false
+        file: ffsend-$TARGET.tar.gz
+        on:
+          tags: true
+          branch: master
+    - stage: release
+      rust: stable
+      env: TARGET=i686-unknown-linux-gnu
+      install: &install-github-release-cross
+        - cargo install cross
+      script: &script-github-release-cross
+        - cross build --target $TARGET --release --verbose --all
+        - cd target/release
+        - tar -czvf $TRAVIS_BUILD_DIR/ffsend-$TARGET.tar.gz ffsend
+        - cd $TRAVIS_BUILD_DIR
+      deploy: *deploy-github-release-cross
+
+    # GitHub binary release for Linux on arch
+    - stage: release
+      rust: stable
+      env: TARGET=aarch64-unknown-linux-gnu
+      install: *install-github-release-cross
+      script: *script-github-release-cross
+      deploy: *deploy-github-release-cross
+    - stage: release
+      rust: stable
+      install: *install-github-release-cross
+      script: *script-github-release-cross
+      deploy: *deploy-github-release-cross
+    - stage: release
+      rust: stable
+      env: TARGET=armv7-unknown-linux-gnueabihf
+      install: *install-github-release-cross
+      script: *script-github-release-cross
+      deploy: *deploy-github-release-cross
+
+    # GitHub binary release for macOX
+    - stage: release
+      rust: stable
+      os: osx
+      env: TARGET=x86_64-apple-darwin
+      script:
+        - cargo build --release --verbose --all
+        - cd target/release
+        - tar -czvf $TRAVIS_BUILD_DIR/ffsend-$TARGET.tar.gz ffsend
+        - cd $TRAVIS_BUILD_DIR
+      deploy: *deploy-github-release-cross
+
+# TODO: add (Free)BSD architecture
 # TODO: use regular cargo commands for x86_64 linux
 # TODO: release a build for each architecture
 # TODO: enfore the git tag/crate version equality for releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,38 +16,66 @@ jobs:
   include:
     - stage: build
       rust: stable
-      script: &build-script
-        - cargo build --verbose --all
-        - cargo build --no-default-features --verbose --all
-        - cargo build --features no-color --verbose --all
+      env: TARGET=x86_64-unknown-linux-gnu
+      script: &build-script-cross
+        - cargo install cross
+        - cross build --target $TARGET --verbose --all
+        - cross build --target $TARGET --no-default-features --verbose --all
+        - cross build --target $TARGET --features no-color --verbose --all
       cache: cargo
     - stage: build
+      rust: stable
+      env: TARGET=i686-unknown-linux-gnu
+      script: *build-script-cross
+    - stage: build
+      rust: stable
+      env: TARGET=aarch64-unknown-linux-gnu
+      script: *build-script-cross
+    - stage: build
       rust: beta
-      script: *build-script
+      env: TARGET=x86_64-unknown-linux-gnu
+      script: *build-script-cross
     - stage: build
       rust: nightly
-      script: *build-script
+      env: TARGET=x86_64-unknown-linux-gnu
+      script: *build-script-cross
     - stage: build
       rust: stable
       os: osx
-      script: *build-script
+      env: TARGET=x86_64-unknown-linux-gnu
+      script:
+        - cargo build --verbose --all
+        - cargo build --no-default-features --verbose --all
+        - cargo build --features no-color --verbose --all
     - stage: test
+      env: TARGET=x86_64-unknown-linux-gnu
       script: cargo test --verbose --all
       cache: cargo
     - stage: release
-      script: skip
+      env: TARGET=x86_64-unknown-linux-gnu
+      script:
+        - cargo install cross
+        - cross build --target $TARGET --release --verbose --all
+        - cd target/release
+        - tar -czvf $TRAVIS_BUILD_DIR/ffsend-linux-x86_64.tar.gz ffsend
+        - cd $TRAVIS_BUILD_DIR
       deploy:
         provider: releases
         api_key: $GITHUB_OAUTH_TOKEN
         skip_cleanup: true
+        overwrite: false
+        file: ffsend-x86_64-linux.tar.gz
         on:
           tags: true
           branch: master
+      cache: cargo
     - stage: release
       script:
         - echo $CARGO_TOKEN | cargo login
         - cargo publish --verbose
       cache: cargo
 
+# TODO: more architectures
+# TODO: release a build for each architecture
 # TODO: enfore the git tag/crate version equality for releases
 # TODO: disable addons/rust installation for GitHub release job

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ jobs:
         on:
           tags: true
           branch: master
+      cache: cargo
     - stage: release
       rust: stable
       env: TARGET=i686-unknown-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # Configuration for Travis CI
 language: rust
-sudo: false
+sudo: required
+services:
+  - docker
 addons:
   apt:
     packages:


### PR DESCRIPTION
This pull request modifies the Travis CI configuration, to build proper releases for the following platform configurations:

- `x86_64-unknown-linux-gnu`
- `i686-unknown-linux-gnu`
- `aarch64-unknown-linux-gnu`
- `arm-unknown-linux-gnueabi`
- `armv7-unknown-linux-gnueabihf`
- `x86_64-apple-darwin`

Each release is then pushed as GitHub release file. Along with these releases, a new crate version is also pushed to the crate registry. The four test builds are kept intact, which will run on every commit.