### PR TITLE
specify which version of openssl to install in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ all available subcommands.
 - Windows specific:
   - OpenSSL v1.1.0j: [» Installer][openssl-windows-installer]
 - macOS specific:
-  - OpenSSL: `brew install openssl`
+  - OpenSSL: `brew install openssl@1.1`
 
 ## Install
 <!-- Before installing, make sure you meet all requirements listed
@@ -232,7 +232,7 @@ globally available:
 
 ```bash
 # Install openssl dependency
-homebrew install openssl
+brew install openssl@1.1
 
 # Rename file to ffsend
 mv ./ffsend-* ./ffsend


### PR DESCRIPTION
Ran into `dyld: Library not loaded: /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib` when installing openssl even after `brew update`. However installing openssl 1.1 solve the issue, hence this PR.