### PR TITLE
Add auto completions for bash and fish shell.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -271,16 +271,16 @@ package-aur:
     - echo "Determining SHA checksums for remote files..."
     - URL_BIN=https://github.com/timvisee/ffsend/releases/download/v$VERSION/ffsend-v$VERSION-linux-x64-static
     - URL_SOURCE=https://gitlab.com/timvisee/ffsend/-/archive/v$VERSION/ffsend-v$VERSION.tar.gz
-    - BASH_COMPLETION="https://raw.githubusercontent.com/timvisee/ffsend/master/contrib/completions/ffsend.bash"
-    - FISH_COMPLETION="https://raw.githubusercontent.com/timvisee/ffsend/master/contrib/completions/ffsend.fish"
+    - BASH_COMPLETION="https://raw.githubusercontent.com/timvisee/ffsend/v$VERSION/contrib/completions/ffsend.bash"
+    - FISH_COMPLETION="https://raw.githubusercontent.com/timvisee/ffsend/v$VERSION/contrib/completions/ffsend.fish"
     - 'echo "Selected binary URL: $URL_BIN"'
     - 'echo "Selected source URL: $URL_SOURCE"'
     - echo "Determining sha256sum for remote binary..."
     - 'SHA_BIN=$(curl -sSL "$URL_BIN" | sha256sum | cut -d" " -f1)'
     - 'echo "Got sha256sum: $SHA_BIN"'
-    - 'SHA_BASH_COMPLETION=$(curl -sSL "BASH_COMPLETION" | sha256sum | cut -d" " -f1)'
+    - 'SHA_BASH_COMPLETION=$(curl -sSL "$BASH_COMPLETION" | sha256sum | cut -d" " -f1)'
     - 'echo "Got sha256sums of bash completion: $SHA_BASH_COMPLETION"'
-    - 'SHA_FISH_COMPLETION=$(curl -sSL "FISH_COMPLETION" | sha256sum | cut -d" " -f1)'
+    - 'SHA_FISH_COMPLETION=$(curl -sSL "$FISH_COMPLETION" | sha256sum | cut -d" " -f1)'
     - 'echo "Got sha256sums of fish completion: $SHA_FISH_COMPLETION"'
     - echo "Determining sha256sum for remote source..."
     - 'SHA_SOURCE=$(curl -sSL "$URL_SOURCE" | sha256sum | cut -d" " -f1)'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -271,11 +271,17 @@ package-aur:
     - echo "Determining SHA checksums for remote files..."
     - URL_BIN=https://github.com/timvisee/ffsend/releases/download/v$VERSION/ffsend-v$VERSION-linux-x64-static
     - URL_SOURCE=https://gitlab.com/timvisee/ffsend/-/archive/v$VERSION/ffsend-v$VERSION.tar.gz
+    - BASH_COMPLETION="https://raw.githubusercontent.com/timvisee/ffsend/master/contrib/completions/ffsend.bash"
+    - FISH_COMPLETION="https://raw.githubusercontent.com/timvisee/ffsend/master/contrib/completions/ffsend.fish"
     - 'echo "Selected binary URL: $URL_BIN"'
     - 'echo "Selected source URL: $URL_SOURCE"'
     - echo "Determining sha256sum for remote binary..."
     - 'SHA_BIN=$(curl -sSL "$URL_BIN" | sha256sum | cut -d" " -f1)'
     - 'echo "Got sha256sum: $SHA_BIN"'
+    - 'SHA_BASH_COMPLETION=$(curl -sSL "BASH_COMPLETION" | sha256sum | cut -d" " -f1)'
+    - 'echo "Got sha256sums of bash completion: $SHA_BASH_COMPLETION"'
+    - 'SHA_FISH_COMPLETION=$(curl -sSL "FISH_COMPLETION" | sha256sum | cut -d" " -f1)'
+    - 'echo "Got sha256sums of fish completion: $SHA_FISH_COMPLETION"'
     - echo "Determining sha256sum for remote source..."
     - 'SHA_SOURCE=$(curl -sSL "$URL_SOURCE" | sha256sum | cut -d" " -f1)'
     - 'echo "Got sha256sum: $SHA_SOURCE"'
@@ -288,7 +294,7 @@ package-aur:
     - sed "s/^source=(\"\(.*\)::.*\").*\$/source=(\"\1::$(echo $URL_SOURCE | sed 's/\//\\\//g')\")/" -i ffsend/PKGBUILD
     - sed "s/^source=(\"\(.*\)::.*\").*\$/source=(\"\1::$(echo $URL_BIN | sed 's/\//\\\//g')\")/" -i ffsend-bin/PKGBUILD
     - sed "s/^sha256sums=.*\$/sha256sums=('$SHA_SOURCE')/" -i ffsend/PKGBUILD
-    - sed "s/^sha256sums=.*\$/sha256sums=('$SHA_BIN')/" -i ffsend-bin/PKGBUILD
+    - sed "s/^sha256sums=.*\$/sha256sums=('$SHA_BIN' '$SHA_BASH_COMPLETION' '$SHA_FISH_COMPLETION')/" -i ffsend-bin/PKGBUILD
 
     # Get SHA hash for local and remote file w/o version, update if it has changed
     - 'SHA_STRIP_LOCAL=$(cat ffsend-git/PKGBUILD | sed /^pkgver=.\*/d | sha256sum | cut -d" " -f1)'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -271,16 +271,16 @@ package-aur:
     - echo "Determining SHA checksums for remote files..."
     - URL_BIN=https://github.com/timvisee/ffsend/releases/download/v$VERSION/ffsend-v$VERSION-linux-x64-static
     - URL_SOURCE=https://gitlab.com/timvisee/ffsend/-/archive/v$VERSION/ffsend-v$VERSION.tar.gz
-    - BASH_COMPLETION="https://raw.githubusercontent.com/timvisee/ffsend/v$VERSION/contrib/completions/ffsend.bash"
-    - FISH_COMPLETION="https://raw.githubusercontent.com/timvisee/ffsend/v$VERSION/contrib/completions/ffsend.fish"
+    - URL_BASH_COMPLETION=https://gitlab.com/timvisee/ffsend/raw/v$VERSION/contrib/completions/ffsend.bash
+    - URL_FISH_COMPLETION=https://gitlab.com/timvisee/ffsend/raw/v$VERSION/contrib/completions/ffsend.fish
     - 'echo "Selected binary URL: $URL_BIN"'
     - 'echo "Selected source URL: $URL_SOURCE"'
     - echo "Determining sha256sum for remote binary..."
     - 'SHA_BIN=$(curl -sSL "$URL_BIN" | sha256sum | cut -d" " -f1)'
     - 'echo "Got sha256sum: $SHA_BIN"'
-    - 'SHA_BASH_COMPLETION=$(curl -sSL "$BASH_COMPLETION" | sha256sum | cut -d" " -f1)'
+    - 'SHA_BASH_COMPLETION=$(curl -sSL "$URL_BASH_COMPLETION" | sha256sum | cut -d" " -f1)'
     - 'echo "Got sha256sums of bash completion: $SHA_BASH_COMPLETION"'
-    - 'SHA_FISH_COMPLETION=$(curl -sSL "$FISH_COMPLETION" | sha256sum | cut -d" " -f1)'
+    - 'SHA_FISH_COMPLETION=$(curl -sSL "$URL_FISH_COMPLETION" | sha256sum | cut -d" " -f1)'
     - 'echo "Got sha256sums of fish completion: $SHA_FISH_COMPLETION"'
     - echo "Determining sha256sum for remote source..."
     - 'SHA_SOURCE=$(curl -sSL "$URL_SOURCE" | sha256sum | cut -d" " -f1)'
@@ -292,7 +292,9 @@ package-aur:
     - sed "s/^pkgver=.*\$/pkgver=$VERSION/" -i ffsend-bin/PKGBUILD
     - sed "s/^pkgver=.*\$/pkgver=$VERSION.$CI_COMMIT_SHORT_SHA/" -i ffsend-git/PKGBUILD
     - sed "s/^source=(\"\(.*\)::.*\").*\$/source=(\"\1::$(echo $URL_SOURCE | sed 's/\//\\\//g')\")/" -i ffsend/PKGBUILD
-    - sed "s/^source=(\"\(.*\)::.*\").*\$/source=(\"\1::$(echo $URL_BIN | sed 's/\//\\\//g')\")/" -i ffsend-bin/PKGBUILD
+    - sed "s/\(\"ffsend-v\$pkgver::\).*\"/\1$URL_BIN\"/" -i ffsend-bin/PKGBUILD
+    - sed "s/\(\"ffsend-v\$pkgver.bash::\).*\"/\1$URL_BASH_COMPLETION\"/" -i ffsend-bin/PKGBUILD
+    - sed "s/\(\"ffsend-v\$pkgver.fish::\).*\"/\1$URL_FISH_COMPLETION\"/" -i ffsend-bin/PKGBUILD
     - sed "s/^sha256sums=.*\$/sha256sums=('$SHA_SOURCE')/" -i ffsend/PKGBUILD
     - sed "s/^sha256sums=.*\$/sha256sums=('$SHA_BIN' '$SHA_BASH_COMPLETION' '$SHA_FISH_COMPLETION')/" -i ffsend-bin/PKGBUILD
 

--- a/pkg/aur/ffsend-bin/PKGBUILD
+++ b/pkg/aur/ffsend-bin/PKGBUILD
@@ -6,19 +6,29 @@
 # - Mirror: https://github.com/timvisee/ffsend/blob/master/pkg/aur/ffsend-bin/PKGBUILD
 
 pkgname=ffsend-bin
-pkgver=0.0.0 # automatically set in CI, see: /.gitlab-ci.yml
+pkgver=0.2.42 # automatically set in CI, see: /.gitlab-ci.yml
 pkgrel=1
 pkgdesc="Easily and securely share files from the command line. A Firefox Send client."
 url="https://gitlab.com/timvisee/ffsend"
 license=('GPL3')
-source=("ffsend-v${pkgver}::https://github.com/timvisee/ffsend/releases/download/v$pkgver/ffsend-v$pkgver-linux-x64-static") # automatically set in CI, see: /.gitlab-ci.yml
-sha256sums=('SKIP') # automatically set in CI, see: /.gitlab-ci.yml
+source=("ffsend-v${pkgver}::https://github.com/timvisee/ffsend/releases/download/v$pkgver/ffsend-v$pkgver-linux-x64-static"
+        "ffsent.bash::https://raw.githubusercontent.com/timvisee/ffsend/master/contrib/completions/ffsend.bash"
+        "ffsend.fish::https://raw.githubusercontent.com/timvisee/ffsend/master/contrib/completions/ffsend.fish") # automatically set in CI, see: /.gitlab-ci.yml
+sha256sums=('SKIP')
 arch=('x86_64')
 provides=('ffsend')
 conflicts=('ffsend')
 depends=('ca-certificates')
-optdepends=('xclip: clipboard support')
+optdepends=('xclip: clipboard support'
+            'bash-completion: support auto completion for bash')
 
 package() {
-    install -Dm755 "$srcdir/ffsend-v${pkgver}" "$pkgdir/usr/bin/ffsend"
+    cd "${srcdir}"
+
+    # Install Binary
+    install -Dm755 "ffsend" "$pkgdir/usr/bin/ffsend"
+
+    # Install completions
+    install -Dm644 "ffsend.bash" "${pkgver}/usr/share/bash-completion/completions/ffsend"
+    install -Dm644 "ffsend.fish" "${pkgver}/usr/share/fish/vendor_completions.d/ffsend.fish"
 }

--- a/pkg/aur/ffsend-bin/PKGBUILD
+++ b/pkg/aur/ffsend-bin/PKGBUILD
@@ -6,14 +6,14 @@
 # - Mirror: https://github.com/timvisee/ffsend/blob/master/pkg/aur/ffsend-bin/PKGBUILD
 
 pkgname=ffsend-bin
-pkgver=0.2.42 # automatically set in CI, see: /.gitlab-ci.yml
+pkgver=0.0.0 # automatically set in CI, see: /.gitlab-ci.yml
 pkgrel=1
 pkgdesc="Easily and securely share files from the command line. A Firefox Send client."
 url="https://gitlab.com/timvisee/ffsend"
 license=('GPL3')
-source=("ffsend-v${pkgver}::https://github.com/timvisee/ffsend/releases/download/v$pkgver/ffsend-v$pkgver-linux-x64-static"
-        "ffsent.bash::https://raw.githubusercontent.com/timvisee/ffsend/master/contrib/completions/ffsend.bash"
-        "ffsend.fish::https://raw.githubusercontent.com/timvisee/ffsend/master/contrib/completions/ffsend.fish") # automatically set in CI, see: /.gitlab-ci.yml
+source=("ffsend-v$pkgver::https://github.com/timvisee/ffsend/releases/download/v$pkgver/ffsend-v$pkgver-linux-x64-static"
+        "ffsend-v$pkgver.bash::https://raw.githubusercontent.com/timvisee/ffsend/v$pkgver/contrib/completions/ffsend.bash"
+        "ffsend-v$pkgver.fish::https://raw.githubusercontent.com/timvisee/ffsend/v$pkgver/contrib/completions/ffsend.fish") # automatically set in CI, see: /.gitlab-ci.yml
 sha256sums=('SKIP')
 arch=('x86_64')
 provides=('ffsend')
@@ -23,12 +23,12 @@ optdepends=('xclip: clipboard support'
             'bash-completion: support auto completion for bash')
 
 package() {
-    cd "${srcdir}"
+    cd "$srcdir"
 
     # Install Binary
-    install -Dm755 "ffsend" "$pkgdir/usr/bin/ffsend"
+    install -Dm755 "ffsend-v$pkgver" "$pkgdir/usr/bin/ffsend"
 
     # Install completions
-    install -Dm644 "ffsend.bash" "${pkgver}/usr/share/bash-completion/completions/ffsend"
-    install -Dm644 "ffsend.fish" "${pkgver}/usr/share/fish/vendor_completions.d/ffsend.fish"
+    install -Dm644 "ffsend-v$pkgver.bash" "$pkgver/usr/share/bash-completion/completions/ffsend"
+    install -Dm644 "ffsend-v$pkgver.fish" "$pkgver/usr/share/fish/vendor_completions.d/ffsend.fish"
 }

--- a/pkg/aur/ffsend-git/PKGBUILD
+++ b/pkg/aur/ffsend-git/PKGBUILD
@@ -26,13 +26,13 @@ build() {
 }
 
 package() {
-    cd "${srcdir}/ffsend"
+    cd "$srcdir/ffsend"
 
     # Install Binary
     install -Dm755 "./target/release/ffsend" "$pkgdir/usr/bin/ffsend"
 
     # Install completions
     cd "./contrib/completions"
-    install -Dm644 "ffsend.bash" "${pkgver}/usr/share/bash-completion/completions/ffsend"
-    install -Dm644 "ffsend.fish" "${pkgver}/usr/share/fish/vendor_completions.d/ffsend.fish"
+    install -Dm644 "ffsend.bash" "$pkgver/usr/share/bash-completion/completions/ffsend"
+    install -Dm644 "ffsend.fish" "$pkgver/usr/share/fish/vendor_completions.d/ffsend.fish"
 }

--- a/pkg/aur/ffsend-git/PKGBUILD
+++ b/pkg/aur/ffsend-git/PKGBUILD
@@ -17,7 +17,8 @@ provides=('ffsend')
 conflicts=('ffsend')
 depends=('ca-certificates')
 makedepends=('openssl>=1.0' 'rust>=1.32' 'cargo' 'cmake')
-optdepends=('xclip: clipboard support')
+optdepends=('xclip: clipboard support'
+            'bash-completion: support auto completion for bash')
 
 build() {
     cd ffsend
@@ -25,5 +26,13 @@ build() {
 }
 
 package() {
-    install -Dm755 "$srcdir/ffsend/target/release/ffsend" "$pkgdir/usr/bin/ffsend"
+    cd "${srcdir}/ffsend"
+
+    # Install Binary
+    install -Dm755 "./target/release/ffsend" "$pkgdir/usr/bin/ffsend"
+
+    # Install completions
+    cd "./contrib/completions"
+    install -Dm644 "ffsend.bash" "${pkgver}/usr/share/bash-completion/completions/ffsend"
+    install -Dm644 "ffsend.fish" "${pkgver}/usr/share/fish/vendor_completions.d/ffsend.fish"
 }

--- a/pkg/aur/ffsend/PKGBUILD
+++ b/pkg/aur/ffsend/PKGBUILD
@@ -25,13 +25,13 @@ build() {
 }
 
 package() {
-    cd "${srcdir}/ffsend-v${pkgver}"
+    cd "$srcdir/ffsend-v$pkgver"
 
     # Install Binary
     install -Dm755 "./target/release/ffsend" "$pkgdir/usr/bin/ffsend"
 
     # Install completions
     cd "./contrib/completions"
-    install -Dm644 "ffsend.bash" "${pkgver}/usr/share/bash-completion/completions/ffsend"
-    install -Dm644 "ffsend.fish" "${pkgver}/usr/share/fish/vendor_completions.d/ffsend.fish"
+    install -Dm644 "ffsend.bash" "$pkgver/usr/share/bash-completion/completions/ffsend"
+    install -Dm644 "ffsend.fish" "$pkgver/usr/share/fish/vendor_completions.d/ffsend.fish"
 }

--- a/pkg/aur/ffsend/PKGBUILD
+++ b/pkg/aur/ffsend/PKGBUILD
@@ -16,7 +16,8 @@ arch=('x86_64' 'i686')
 provides=('ffsend')
 depends=('ca-certificates')
 makedepends=('openssl>=1.0' 'rust>=1.32' 'cargo' 'cmake')
-optdepends=('xclip: clipboard support')
+optdepends=('xclip: clipboard support'
+            'bash-completion: support auto completion for bash')
 
 build() {
     cd "ffsend-v$pkgver"
@@ -24,5 +25,13 @@ build() {
 }
 
 package() {
-    install -Dm755 "$srcdir/ffsend-v$pkgver/target/release/ffsend" "$pkgdir/usr/bin/ffsend"
+    cd "${srcdir}/ffsend-v${pkgver}"
+
+    # Install Binary
+    install -Dm755 "./target/release/ffsend" "$pkgdir/usr/bin/ffsend"
+
+    # Install completions
+    cd "./contrib/completions"
+    install -Dm644 "ffsend.bash" "${pkgver}/usr/share/bash-completion/completions/ffsend"
+    install -Dm644 "ffsend.fish" "${pkgver}/usr/share/fish/vendor_completions.d/ffsend.fish"
 }


### PR DESCRIPTION
I have to modify the travis ci configuration file to get the sha256sums of completion files for the `ffsend-bin`. If there are ci issues with this commit, please correct me for it. Thanks a lot :see_no_evil: .