### PR TITLE
chore: Include contrib folder into the crates.io tarball

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ categories = [
 ]
 exclude = [
     "/.github",
-    "/contrib",
     "/pkg",
     "/res",
     "/*.yml",


### PR DESCRIPTION
Otherwise distributions can't make completions available.