### PR TITLE
Upgrade linux/Arch builds to use libssl3.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,9 +95,9 @@ build-x86_64-linux-musl:
 
     # Build OpenSSL statically
     - apt-get install -y build-essential wget musl-tools
-    - wget https://www.openssl.org/source/old/1.1.1/openssl-1.1.1k.tar.gz
-    - tar xzvf openssl-1.1.1k.tar.gz
-    - cd openssl-1.1.1k
+    - wget https://www.openssl.org/source/openssl-3.0.8.tar.gz
+    - tar xzvf openssl-3.0.8.tar.gz
+    - cd openssl-3.0.8
     - ./config no-async -fPIC --openssldir=/usr/local/ssl --prefix=/usr/local
     - make
     - make install

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ An optional password may be specified, and a default file lifetime of 1 \
 remain online forever. This provides a secure platform to share your files."""
 priority = "standard"
 license-file = ["LICENSE", "3"]
-depends = "$auto, libssl1.1, ca-certificates, xclip"
+depends = "$auto, libssl3, ca-certificates, xclip"
 maintainer-scripts = "pkg/deb"
 
 [[bin]]

--- a/pkg/aur/ffsend-git/PKGBUILD
+++ b/pkg/aur/ffsend-git/PKGBUILD
@@ -16,7 +16,7 @@ arch=('x86_64' 'i686')
 provides=('ffsend')
 conflicts=('ffsend')
 depends=('ca-certificates')
-makedepends=('cargo' 'cmake' 'openssl>=1.0')
+makedepends=('cargo' 'cmake' 'openssl')
 optdepends=('xclip: clipboard support')
 
 prepare() {

--- a/pkg/aur/ffsend/PKGBUILD
+++ b/pkg/aur/ffsend/PKGBUILD
@@ -14,7 +14,7 @@ source=("$url/-/archive/v$pkgver/ffsend-v$pkgver.tar.gz") # automatically set in
 sha256sums=('SKIP') # automatically set in CI, see: /.gitlab-ci.yml
 arch=('x86_64' 'i686')
 depends=('ca-certificates')
-makedepends=('cargo' 'cmake' 'openssl>=1.0')
+makedepends=('cargo' 'cmake' 'openssl')
 optdepends=('xclip: clipboard support')
 
 prepare() {

--- a/pkg/snap/snapcraft.yaml
+++ b/pkg/snap/snapcraft.yaml
@@ -32,4 +32,4 @@ parts:
     plugin: rust
     build-attributes: [no-system-libraries]
     build-packages: [make, cmake, pkg-config, libssl-dev]
-    stage-packages: [libssl1.0.0, xclip]
+    stage-packages: [libssl3, xclip]


### PR DESCRIPTION
Aims to at least partially implement #141.

Tested building dynamically linked linux executable (Debian Bookworm) and it built without problems (`cargo build --release`).
Ran `cargo test` and there were no errors. A couple warnings though, in code I didn't touch.

~I have not tested if it builds on Arch yet (will create a VM today and test it).~

Building via Cargo was successful on Arch.