### PR TITLE
Upgrade to OpenSSL 3.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@
 # - export a build artifact from the new job
 # - manually upload artifact to GitHub in the 'github-release' job
 
-image: "rust:slim"
+image: "rust:slim-bookworm"
 
 stages:
   - check

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,9 +95,9 @@ build-x86_64-linux-musl:
 
     # Build OpenSSL statically
     - apt-get install -y build-essential wget musl-tools
-    - wget https://www.openssl.org/source/openssl-3.0.14.tar.gz
-    - tar xzvf openssl-3.0.14.tar.gz
-    - cd openssl-3.0.14
+    - wget https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz
+    - tar xzvf openssl-3.0.15.tar.gz
+    - cd openssl-3.0.15
     - ./config no-async -fPIC --openssldir=/usr/local/ssl --prefix=/usr/local
     - make
     - make install

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,9 +95,9 @@ build-x86_64-linux-musl:
 
     # Build OpenSSL statically
     - apt-get install -y build-essential wget musl-tools
-    - wget https://www.openssl.org/source/old/1.1.1/openssl-1.1.1k.tar.gz
-    - tar xzvf openssl-1.1.1k.tar.gz
-    - cd openssl-1.1.1k
+    - wget https://www.openssl.org/source/openssl-3.0.14.tar.gz
+    - tar xzvf openssl-3.0.14.tar.gz
+    - cd openssl-3.0.14
     - ./config no-async -fPIC --openssldir=/usr/local/ssl --prefix=/usr/local
     - make
     - make install

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,7 +105,7 @@ build-x86_64-linux-musl:
 
     # Statically build ffsend
     - export OPENSSL_STATIC=1
-    - export OPENSSL_LIB_DIR=/usr/local/lib
+    - export OPENSSL_LIB_DIR=/usr/local/lib64
     - export OPENSSL_INCLUDE_DIR=/usr/local/include
     - cargo build --target=$RUST_TARGET --release --verbose
 


### PR DESCRIPTION
Originally did this as an MR on [Gitlab](https://gitlab.com/timvisee/ffsend/-/merge_requests/43), but it seems to me the project is more active here on Github, so here it is again. (And this time the build works with fine regarding MUSL-builds etc. on Gitlab.)

Ditched OpenSSL 1.x in favor of the current OpenSSL 3.0 LTS release.